### PR TITLE
Fix wrong function name in model interpretation

### DIFF
--- a/wittgenstein/interpret.py
+++ b/wittgenstein/interpret.py
@@ -91,9 +91,9 @@ def model_predict(X, model, model_predict_function=None):
             return _sklearn_predict(X, model)
         elif _inpackage(model, "tensorflow") or _inpackage(model, "keras"):
             return _keras_predict(X, model)
-        elif inpackage(model, "torch"):
+        elif _inpackage(model, "torch"):
             return _torch_predict(X, model)
-        elif inpackage(model, "wittgenstein"):
+        elif _inpackage(model, "wittgenstein"):
             return _wittgenstein_predict(X, model)
         else:
             return model.predict(X)


### PR DESCRIPTION
I was getting an error about the `inpackage` function not existing, it turns out there was a typo, as the function is called `_inpackage`. 

I found this by trying out the model interpretation functionality by passing a CatBoost model, without supplying my own `model_predict_function`.  So the error popped up in the 3rd if statement.